### PR TITLE
Do not put acknowledgements in a reference note

### DIFF
--- a/inst/rmarkdown/templates/science/resources/template.tex
+++ b/inst/rmarkdown/templates/science/resources/template.tex
@@ -174,16 +174,7 @@ $if(bibliography)$
 \bibliographystyle{Science}
 $endif$
 
-% Following is a new environment, {scilastnote}, that's defined in the
-% preamble and that allows authors to add a reference at the end of the
-% list that's not signaled in the text; such references are used in
-% *Science* for acknowledgments of funding, help, etc.
-
-\begin{scilastnote}
-\item $acknowledgements$
-\end{scilastnote}
-
-
+%% Anything after bibliography
 $for(include-after)$
 $include-after$
 


### PR DESCRIPTION
Per email instructions. Below is what a final version looks like.


Doing the acknowledgements instead in the `include-after` argument works. But without an `acknowledgements` argument there is an awkward blank, so I deleted it all together.



![image](https://user-images.githubusercontent.com/8290417/132960917-b665b068-b342-434d-8602-b995ff1ac632.png)
